### PR TITLE
Add simple Watten game play

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,131 @@
 version = 4
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "watten"
 version = "0.1.0"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rand = "0.8"

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,0 +1,265 @@
+use crate::{deck, shuffle, Card, Rank, Suit};
+use crate::player::Player;
+
+pub const WINNING_POINTS: usize = 13;
+pub const PART_POINTS: usize = 2;
+pub const PART_TRICKS: usize = 5;
+
+pub fn rank_value(r: Rank) -> u8 {
+    match r {
+        Rank::Seven => 1,
+        Rank::Eight => 2,
+        Rank::Nine => 3,
+        Rank::Ten => 4,
+        Rank::Unter => 5,
+        Rank::Ober => 6,
+        Rank::King => 7,
+        Rank::Ace => 8,
+        Rank::Weli => 9,
+    }
+}
+
+pub fn card_strength(card: &Card, lead: Suit, rechte: Card, position: usize) -> i16 {
+    let trump_suit = rechte.suit;
+    let striker_rank = rechte.rank;
+    let base: i16 = if *card == rechte {
+        200
+    } else if card.rank == Rank::Weli {
+        180
+    } else if card.rank == striker_rank {
+        // striker beats any trump except the rechte
+        190
+    } else if card.suit == trump_suit {
+        100 + rank_value(card.rank) as i16
+    } else if card.suit == lead {
+        50 + rank_value(card.rank) as i16
+    } else {
+        rank_value(card.rank) as i16
+    };
+    base * 10 - position as i16
+}
+
+pub struct GameState {
+    pub players: [Player; 4],
+    pub dealer: usize,
+    pub rechte: Option<Card>,
+    pub scores: [usize; 2],
+    pub part_points: usize,
+}
+
+impl GameState {
+    pub fn new(human_players: usize) -> Self {
+        let mut players = [
+            Player::new(false),
+            Player::new(false),
+            Player::new(false),
+            Player::new(false),
+        ];
+        for i in 0..human_players.min(4) {
+            players[i].human = true;
+        }
+        Self {
+            players,
+            dealer: 0,
+            rechte: None,
+            scores: [0, 0],
+            part_points: PART_POINTS,
+        }
+    }
+
+    fn start_part(&mut self) {
+        let mut cards = deck();
+        shuffle(&mut cards);
+        for p in self.players.iter_mut() {
+            p.hand.clear();
+        }
+        for i in 0..PART_TRICKS {
+            for j in 0..4 {
+                let idx = (self.dealer + 1 + j) % 4;
+                self.players[idx].hand.push(cards[i * 4 + j]);
+            }
+        }
+        let dealer_card = self.players[self.dealer].hand[0];
+        let next_idx = (self.dealer + 1) % 4;
+        let next_card = self.players[next_idx].hand[0];
+        self.rechte = Some(Card::new(dealer_card.suit, next_card.rank));
+        println!("Trump suit is {}", dealer_card.suit);
+        println!("Striker rank is {}", next_card.rank);
+        println!("Rechte is {}", self.rechte.unwrap());
+    }
+
+    pub fn trump_suit(&self) -> Option<Suit> {
+        self.rechte.map(|c| c.suit)
+    }
+
+    pub fn striker_rank(&self) -> Option<Rank> {
+        self.rechte.map(|c| c.rank)
+    }
+
+    #[allow(unused_assignments)]
+    pub fn play_part(&mut self) -> usize {
+        self.start_part();
+        let mut tricks = [0usize; 2];
+        let mut lead = (self.dealer + 1) % 4;
+        for _ in 0..PART_TRICKS {
+            let mut played: Vec<(usize, Card)> = Vec::new();
+            let lead_card = {
+                let card = self.players[lead].play_card(None);
+                println!("Player {} plays {}", lead + 1, card);
+                played.push((lead, card));
+                card
+            };
+            let lead_suit = lead_card.suit;
+            for offset in 1..4 {
+                let p_idx = (lead + offset) % 4;
+                let card = self.players[p_idx].play_card(Some(lead_suit));
+                println!("Player {} plays {}", p_idx + 1, card);
+                played.push((p_idx, card));
+            }
+            let rechte = self.rechte.unwrap();
+            let mut best = (played[0].0, played[0].1, 0usize);
+            let mut best_score = card_strength(&best.1, lead_suit, rechte, 0);
+            for (pos, &(idx, ref card)) in played.iter().enumerate().skip(1) {
+                let val = card_strength(card, lead_suit, rechte, pos);
+                if val > best_score {
+                    best = (idx, *card, pos);
+                    best_score = val;
+                }
+            }
+            let (winner_idx, _, _) = best;
+            println!("Player {} wins the trick\n", winner_idx + 1);
+            tricks[winner_idx % 2] += 1;
+            lead = winner_idx;
+        }
+        self.dealer = (self.dealer + 1) % 4;
+        let winner = if tricks[0] > tricks[1] { 0 } else { 1 };
+        self.scores[winner] += self.part_points;
+        winner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn striker_beats_trump() {
+        let rechte = Card::new(Suit::Hearts, Rank::Unter);
+        let striker = Card::new(Suit::Bells, Rank::Unter);
+        let trump_card = Card::new(Suit::Hearts, Rank::Ace);
+        let lead = Suit::Hearts;
+        assert!(
+            card_strength(&striker, lead, rechte, 0)
+                > card_strength(&trump_card, lead, rechte, 0)
+        );
+    }
+
+    #[test]
+    fn rechte_beats_striker() {
+        let rechte = Card::new(Suit::Leaves, Rank::Ober);
+        let striker = Card::new(Suit::Hearts, Rank::Ober);
+        let lead = Suit::Hearts;
+        assert!(
+            card_strength(&rechte, lead, rechte, 0)
+                > card_strength(&striker, lead, rechte, 0)
+        );
+    }
+
+    #[test]
+    fn first_striker_played_beats_striker() {
+        let rechte = Card::new(Suit::Hearts, Rank::Unter);
+        let lead = Suit::Bells;
+        let first = Card::new(Suit::Bells, Rank::Unter);
+        let second = Card::new(Suit::Leaves, Rank::Unter);
+        let mut best = (0usize, first);
+        let best_val = card_strength(&best.1, lead, rechte, 0);
+        let candidate = (1usize, second);
+        let val = card_strength(&candidate.1, lead, rechte, 1);
+        if val > best_val {
+            best = candidate;
+        }
+        assert_eq!(best.0, 0);
+    }
+
+    #[test]
+    fn new_game_has_zero_scores() {
+        let g = GameState::new(0);
+        assert_eq!(g.scores, [0, 0]);
+        assert_eq!(g.part_points, PART_POINTS);
+    }
+
+    #[test]
+    fn play_card_whole_trick_first_striker_wins() {
+        let rechte = Card::new(Suit::Hearts, Rank::Unter);
+        let mut players = [
+            Player::new(false),
+            Player::new(false),
+            Player::new(false),
+            Player::new(false),
+        ];
+        players[0].hand.push(Card::new(Suit::Bells, Rank::Unter));
+        players[1].hand.push(Card::new(Suit::Leaves, Rank::Unter));
+        players[2].hand.push(Card::new(Suit::Hearts, Rank::Ace));
+        players[3].hand.push(Card::new(Suit::Acorns, Rank::Ace));
+
+        let lead_card = players[0].play_card(None);
+        let lead_suit = lead_card.suit;
+        let mut cards = vec![lead_card];
+        for i in 1..4 {
+            cards.push(players[i].play_card(Some(lead_suit)));
+        }
+
+        let mut best_idx = 0usize;
+        let mut best_val = card_strength(&cards[0], lead_suit, rechte, 0);
+        for (pos, card) in cards.iter().enumerate().skip(1) {
+            let val = card_strength(card, lead_suit, rechte, pos);
+            if val > best_val {
+                best_idx = pos;
+                best_val = val;
+            }
+        }
+
+        assert_eq!(best_idx, 0);
+        for p in &players {
+            assert!(p.hand.is_empty());
+        }
+    }
+
+    #[test]
+    fn play_card_whole_trick_rechte_wins_even_last() {
+        let rechte = Card::new(Suit::Hearts, Rank::Unter);
+        let mut players = [
+            Player::new(false),
+            Player::new(false),
+            Player::new(false),
+            Player::new(false),
+        ];
+        players[0].hand.push(Card::new(Suit::Hearts, Rank::Ace));
+        players[1].hand.push(Card::new(Suit::Bells, Rank::Unter));
+        players[2].hand.push(Card::new(Suit::Hearts, Rank::Nine));
+        players[3].hand.push(rechte); // hearts unter
+
+        let lead_card = players[0].play_card(None);
+        let lead_suit = lead_card.suit;
+        let mut cards = vec![lead_card];
+        for i in 1..4 {
+            cards.push(players[i].play_card(Some(lead_suit)));
+        }
+
+        let mut best_idx = 0usize;
+        let mut best_val = card_strength(&cards[0], lead_suit, rechte, 0);
+        for (pos, card) in cards.iter().enumerate().skip(1) {
+            let val = card_strength(card, lead_suit, rechte, pos);
+            if val > best_val {
+                best_idx = pos;
+                best_val = val;
+            }
+        }
+
+        assert_eq!(best_idx, 3);
+        for p in &players {
+            assert!(p.hand.is_empty());
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,18 @@ pub enum Suit {
     Acorns,
 }
 
+impl std::fmt::Display for Suit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Suit::Hearts => "Hearts",
+            Suit::Bells => "Bells",
+            Suit::Leaves => "Leaves",
+            Suit::Acorns => "Acorns",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Rank {
     Seven,
@@ -20,6 +32,23 @@ pub enum Rank {
     Weli,
 }
 
+impl std::fmt::Display for Rank {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Rank::Seven => "7",
+            Rank::Eight => "8",
+            Rank::Nine => "9",
+            Rank::Ten => "10",
+            Rank::Unter => "Unter",
+            Rank::Ober => "Ober",
+            Rank::King => "King",
+            Rank::Ace => "Ace",
+            Rank::Weli => "Weli",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Card {
     pub suit: Suit,
@@ -29,6 +58,12 @@ pub struct Card {
 impl Card {
     pub fn new(suit: Suit, rank: Rank) -> Self {
         Self { suit, rank }
+    }
+}
+
+impl std::fmt::Display for Card {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} of {}", self.rank, self.suit)
     }
 }
 
@@ -46,6 +81,13 @@ pub fn deck() -> Vec<Card> {
     // Add Weli (6 of Bells)
     cards.push(Card::new(Suit::Bells, Weli));
     cards
+}
+
+/// Shuffle a deck of cards in place
+pub fn shuffle(deck: &mut [Card]) {
+    use rand::seq::SliceRandom;
+    let mut rng = rand::thread_rng();
+    deck.shuffle(&mut rng);
 }
 
 /// Number of ways a hand of five cards can be ordered
@@ -223,3 +265,6 @@ mod tests {
         assert_eq!(counts[GameResult::NotPlayed as usize], 0);
     }
 }
+
+pub mod player;
+pub mod game;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,21 @@
+use std::io;
+use watten::game::{GameState, WINNING_POINTS};
+
+fn main() {
+    println!("Play with a human player? [y/N]");
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+    let humans = if input.trim().eq_ignore_ascii_case("y") { 1 } else { 0 };
+
+    let mut game = GameState::new(humans);
+    while game.scores[0] < WINNING_POINTS && game.scores[1] < WINNING_POINTS {
+        println!("\nStarting part. Dealer is player {}\n", game.dealer + 1);
+        game.play_part();
+        println!("Team 1: {} points, Team 2: {} points", game.scores[0], game.scores[1]);
+    }
+    if game.scores[0] >= WINNING_POINTS {
+        println!("Team 1 wins the game!");
+    } else {
+        println!("Team 2 wins the game!");
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,93 @@
+use rand::seq::SliceRandom;
+use std::io::{self, Write};
+
+use crate::{Card, Suit};
+
+#[derive(Clone)]
+pub struct Player {
+    pub hand: Vec<Card>,
+    pub human: bool,
+}
+
+impl Player {
+    pub fn new(human: bool) -> Self {
+        Self {
+            hand: Vec::new(),
+            human,
+        }
+    }
+
+    pub fn play_card(&mut self, lead: Option<Suit>) -> Card {
+        // determine playable card indices
+        let playable: Vec<usize> = if let Some(s) = lead {
+            let inds: Vec<usize> = self
+                .hand
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| c.suit == s)
+                .map(|(i, _)| i)
+                .collect();
+            if inds.is_empty() {
+                (0..self.hand.len()).collect()
+            } else {
+                inds
+            }
+        } else {
+            (0..self.hand.len()).collect()
+        };
+
+        if self.human {
+            loop {
+                println!("Your hand:");
+                for (i, c) in self.hand.iter().enumerate() {
+                    println!("  {}: {}", i + 1, c);
+                }
+                print!("Select card to play: ");
+                io::stdout().flush().unwrap();
+                let mut input = String::new();
+                io::stdin().read_line(&mut input).unwrap();
+                if let Ok(idx) = input.trim().parse::<usize>() {
+                    if idx >= 1 && idx <= self.hand.len() && playable.contains(&(idx - 1)) {
+                        return self.hand.remove(idx - 1);
+                    }
+                }
+                println!("Invalid choice, try again.");
+            }
+        } else {
+            let idx = *playable.choose(&mut rand::thread_rng()).unwrap();
+            self.hand.remove(idx)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Rank, Suit};
+
+    #[test]
+    fn follow_suit_if_possible() {
+        let mut p = Player::new(false);
+        p.hand = vec![
+            Card::new(Suit::Hearts, Rank::Seven),
+            Card::new(Suit::Bells, Rank::Eight),
+            Card::new(Suit::Leaves, Rank::Nine),
+        ];
+        let card = p.play_card(Some(Suit::Hearts));
+        assert_eq!(card.suit, Suit::Hearts);
+        assert_eq!(p.hand.len(), 2);
+    }
+
+    #[test]
+    fn play_any_if_no_follow() {
+        let mut p = Player::new(false);
+        p.hand = vec![
+            Card::new(Suit::Bells, Rank::Eight),
+            Card::new(Suit::Leaves, Rank::Nine),
+        ];
+        let card = p.play_card(Some(Suit::Hearts));
+        assert!(card.suit == Suit::Bells || card.suit == Suit::Leaves);
+        assert_eq!(p.hand.len(), 1);
+    }
+}
+


### PR DESCRIPTION
## Summary
- support pretty-printing of suits, ranks and cards
- add shuffling helper
- implement a playable game in `src/main.rs`
- use `rand` for randomness
- add full trick tests using `play_card`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684160ca22c48324b2024e94dd0a1bc5