### PR TITLE
Refactor game database into API module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The crate provides:
 
 - A 33 card deck used in the game
 - Utilities for enumerating all 120 possible orders in which a 5‑card hand can be played
-- A `GameDatabase` that maps ordered plays of four players to a result (team 1/2 win, not played or rule violation)
+- A database API that maps ordered plays of four players to a result (team 1/2 win, not played or rule violation)
 - Functions for computing permutation ranges so partially played games can be matched
 
 Run tests with `cargo test`.

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use std::ops::Range;
+
+use crate::{GameResult, HAND_PERMUTATIONS};
+
+/// API for accessing the game database.
+pub trait GameDatabase {
+    fn set(&mut self, p1: usize, p2: usize, p3: usize, p4: usize, result: GameResult);
+    fn get(&self, p1: usize, p2: usize, p3: usize, p4: usize) -> GameResult;
+    fn counts_in_ranges(
+        &self,
+        p1: Range<usize>,
+        p2: Range<usize>,
+        p3: Range<usize>,
+        p4: Range<usize>,
+    ) -> [u32; 4];
+}
+
+/// In-memory implementation of [`GameDatabase`].
+pub struct InMemoryGameDatabase {
+    results: HashMap<u32, GameResult>,
+}
+
+impl InMemoryGameDatabase {
+    pub fn new() -> Self {
+        Self {
+            results: HashMap::new(),
+        }
+    }
+
+    fn make_index(p1: usize, p2: usize, p3: usize, p4: usize) -> u32 {
+        (((p1 * HAND_PERMUTATIONS + p2) * HAND_PERMUTATIONS + p3) * HAND_PERMUTATIONS + p4) as u32
+    }
+}
+
+impl GameDatabase for InMemoryGameDatabase {
+    fn set(&mut self, p1: usize, p2: usize, p3: usize, p4: usize, result: GameResult) {
+        let idx = Self::make_index(p1, p2, p3, p4);
+        self.results.insert(idx, result);
+    }
+
+    fn get(&self, p1: usize, p2: usize, p3: usize, p4: usize) -> GameResult {
+        let idx = Self::make_index(p1, p2, p3, p4);
+        *self.results.get(&idx).unwrap_or(&GameResult::NotPlayed)
+    }
+
+    fn counts_in_ranges(
+        &self,
+        p1: Range<usize>,
+        p2: Range<usize>,
+        p3: Range<usize>,
+        p4: Range<usize>,
+    ) -> [u32; 4] {
+        let mut counts = [0u32; 4];
+        for i1 in p1.clone() {
+            for i2 in p2.clone() {
+                for i3 in p3.clone() {
+                    for i4 in p4.clone() {
+                        let r = self.get(i1, i2, i3, i4) as usize;
+                        counts[r] += 1;
+                    }
+                }
+            }
+        }
+        counts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_over_range() {
+        let mut db = InMemoryGameDatabase::new();
+        db.set(0, 0, 0, 0, GameResult::Team1Win);
+        let counts = db.counts_in_ranges(0..1, 0..1, 0..1, 0..1);
+        assert_eq!(counts[GameResult::Team1Win as usize], 1);
+        assert_eq!(counts[GameResult::NotPlayed as usize], 0);
+    }
+}

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,6 +1,7 @@
+use crate::database::{GameDatabase, InMemoryGameDatabase};
 use crate::player::Player;
 use crate::{
-    all_hand_orders, deck, perm_prefix_range, shuffle, Card, GameDatabase, GameResult, Rank, Suit,
+    all_hand_orders, deck, perm_prefix_range, shuffle, Card, GameResult, Rank, Suit,
     HAND_PERMUTATIONS,
 };
 
@@ -93,7 +94,7 @@ pub struct GameState {
     pub rechte: Option<Card>,
     pub scores: [usize; 2],
     pub round_points: usize,
-    pub db: GameDatabase,
+    pub db: Box<dyn GameDatabase>,
     orig_hands: [[Card; TRICKS_PER_ROUND]; 4],
     played: [Vec<usize>; 4],
 }
@@ -115,7 +116,7 @@ impl GameState {
             rechte: None,
             scores: [0, 0],
             round_points: ROUND_POINTS,
-            db: GameDatabase::new(),
+            db: Box::new(InMemoryGameDatabase::new()),
             orig_hands: [[DUMMY_CARD; TRICKS_PER_ROUND]; 4],
             played: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
         }
@@ -149,7 +150,7 @@ impl GameState {
     }
 
     fn populate_database(&mut self) {
-        self.db = GameDatabase::new();
+        self.db = Box::new(InMemoryGameDatabase::new());
         let perms = all_hand_orders();
         let rechte = self.rechte.unwrap();
         for (i1, p1) in perms.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,56 +170,7 @@ pub enum GameResult {
     RuleViolation = 3,
 }
 
-use std::collections::HashMap;
-
-/// Database holding evaluated games keyed by permutation index
-pub struct GameDatabase {
-    results: HashMap<u32, GameResult>,
-}
-
-impl GameDatabase {
-    pub fn new() -> Self {
-        Self {
-            results: HashMap::new(),
-        }
-    }
-
-    pub fn make_index(p1: usize, p2: usize, p3: usize, p4: usize) -> u32 {
-        (((p1 * HAND_PERMUTATIONS + p2) * HAND_PERMUTATIONS + p3) * HAND_PERMUTATIONS + p4) as u32
-    }
-
-    pub fn set(&mut self, p1: usize, p2: usize, p3: usize, p4: usize, result: GameResult) {
-        let idx = Self::make_index(p1, p2, p3, p4);
-        self.results.insert(idx, result);
-    }
-
-    pub fn get(&self, p1: usize, p2: usize, p3: usize, p4: usize) -> GameResult {
-        let idx = Self::make_index(p1, p2, p3, p4);
-        *self.results.get(&idx).unwrap_or(&GameResult::NotPlayed)
-    }
-
-    /// Count game results over all index combinations within the provided ranges.
-    pub fn counts_in_ranges(
-        &self,
-        p1: std::ops::Range<usize>,
-        p2: std::ops::Range<usize>,
-        p3: std::ops::Range<usize>,
-        p4: std::ops::Range<usize>,
-    ) -> [u32; 4] {
-        let mut counts = [0u32; 4];
-        for i1 in p1.clone() {
-            for i2 in p2.clone() {
-                for i3 in p3.clone() {
-                    for i4 in p4.clone() {
-                        let r = self.get(i1, i2, i3, i4) as usize;
-                        counts[r] += 1;
-                    }
-                }
-            }
-        }
-        counts
-    }
-}
+pub mod database;
 
 #[cfg(test)]
 mod tests {
@@ -258,7 +209,8 @@ mod tests {
 
     #[test]
     fn db_counts_over_range() {
-        let mut db = GameDatabase::new();
+        use crate::database::{GameDatabase, InMemoryGameDatabase};
+        let mut db = InMemoryGameDatabase::new();
         db.set(0, 0, 0, 0, GameResult::Team1Win);
         let counts = db.counts_in_ranges(0..1, 0..1, 0..1, 0..1);
         assert_eq!(counts[GameResult::Team1Win as usize], 1);
@@ -266,5 +218,5 @@ mod tests {
     }
 }
 
-pub mod player;
 pub mod game;
+pub mod player;


### PR DESCRIPTION
## Summary
- add `database` module with `GameDatabase` trait and `InMemoryGameDatabase`
- adjust `GameState` to use the new API
- document database API in README

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841ffce7cd08324895c6f3d70415231