### PR TITLE
Add raising mechanic to rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The crate provides:
 - Utilities for enumerating all 120 possible orders in which a 5‑card hand can be played
 - A database API that maps ordered plays of four players to a result (team 1/2 win, not played or rule violation)
 - `GameState::play_round` returns the [`GameResult`] of the round
+- `GameState::raise_round` lets teams increase the current round value
 - `play_hand` plays a round with specific hand IDs and returns the result
 - Functions for computing permutation ranges so partially played games can be matched
 


### PR DESCRIPTION
## Summary
- allow teams to raise the point value of the current round
- track which team raised last to prevent consecutive raises by the same team
- reset round points and last raiser at the start of each round
- document `raise_round` API
- test alternating raises

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68446fc778e083249b6201584db6a0da