### PR TITLE
Add full database population test

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+full = "test -- --ignored"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [lib]
 crate-type = ["rlib", "cdylib"]
+
+[alias]
+full = "test -- --ignored"

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ The crate provides:
 - `play_hand` plays a round with specific hand IDs and returns the result
 - Functions for computing permutation ranges so partially played games can be matched
 
-Run tests with `cargo test`. The frontend also has a small
-test suite which can be executed with `npm test` from the
-`frontend` directory.
+Run tests with `cargo test`. Heavier tests that populate the full
+database are ignored by default and can be run with `cargo full`.
+The frontend also has a small test suite which can be executed with
+`npm test` from the `frontend` directory.
 
 ## WebAssembly Frontend
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build:wasm && vite",
     "build": "npm run build:wasm && vite build",
     "serve": "vite preview",
-    "test": "npm run build:wasm:test && node test.js"
+    "test": "npm run build:wasm:test && node test.js && node test_full_game.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/test_full_game.js
+++ b/frontend/test_full_game.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+(async () => {
+  const wasm = await import('../pkg-test/watten.js');
+  const bytes = fs.readFileSync(path.join(__dirname, '..', 'pkg-test', 'watten_bg.wasm'));
+  wasm.initSync(bytes.buffer);
+  const game = new wasm.WasmGame(0);
+  // Limit permutation range so the test runs quickly
+  if (game.set_perm_range_single) {
+    game.set_perm_range_single(0);
+  }
+  const WINNING = 13;
+  let round = 1;
+  while (game.scores()[0] < WINNING && game.scores()[1] < WINNING) {
+    console.log(`\n-- Round ${round} --`);
+    const result = game.play_round();
+    const scores = game.scores();
+    console.log('Scores after round', scores);
+    console.log('Result code', result);
+    round++;
+  }
+  const final = game.scores();
+  console.log('\nFinal scores', final);
+  if (final[0] < WINNING && final[1] < WINNING) {
+    throw new Error('Game did not reach winning score');
+  }
+})();

--- a/src/game.rs
+++ b/src/game.rs
@@ -145,6 +145,18 @@ impl GameState {
         }
     }
 
+    /// Limit the permutation range used when populating the database. Providing
+    /// a single permutation can dramatically speed up tests.
+    pub fn set_perm_range_single(&mut self, idx: usize) {
+        self.perm_range = Some(vec![idx]);
+    }
+
+    /// Clear any permutation restriction so that all permutations are used
+    /// again when populating the database.
+    pub fn clear_perm_range(&mut self) {
+        self.perm_range = None;
+    }
+
     pub fn start_round(&mut self) {
         self.round_points = ROUND_POINTS;
         self.last_raiser = None;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -29,6 +29,19 @@ impl WasmGame {
         self.inner.start_round();
     }
 
+    /// Limit the permutation range used for database population. Providing a
+    /// single permutation drastically speeds up simulations and is useful in
+    /// tests.
+    pub fn set_perm_range_single(&mut self, idx: usize) {
+        self.inner.set_perm_range_single(idx);
+    }
+
+    /// Clear any permutation range so that all permutations are considered
+    /// again.
+    pub fn clear_perm_range(&mut self) {
+        self.inner.clear_perm_range();
+    }
+
     pub fn play_round(&mut self) -> u8 {
         self.inner.play_round() as u8
     }

--- a/tests/full_database.rs
+++ b/tests/full_database.rs
@@ -1,0 +1,22 @@
+use watten::game::GameState;
+use watten::{GameResult, HAND_PERMUTATIONS};
+
+#[test]
+#[ignore]
+fn full_database_population_after_clear() {
+    let mut g = GameState::new(0);
+    // Restrict to a single permutation first
+    g.set_perm_range_single(0);
+    g.start_round();
+    // Only permutation 0 should exist
+    assert_ne!(g.db.get(0, 0, 0, 0), GameResult::NotPlayed);
+    assert_eq!(g.db.get(1, 0, 0, 0), GameResult::NotPlayed);
+
+    // Enable full range and populate again
+    g.clear_perm_range();
+    g.start_round();
+
+    let hi = HAND_PERMUTATIONS - 1;
+    assert_ne!(g.db.get(hi, hi, hi, hi), GameResult::NotPlayed);
+    assert_ne!(g.db.get(1, 0, 0, 0), GameResult::NotPlayed);
+}


### PR DESCRIPTION
## Summary
- add `cargo full` alias for running heavy tests
- document how to run them
- implement `full_database_population_after_clear` ignored test

## Testing
- `cargo test --quiet`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a153773588324964148b32145b482