### PR TITLE
Optimize DB counting over restricted permutations

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -18,13 +18,7 @@ pub trait GameDatabase {
     /// Count results over explicit lists of permutation indices. This allows
     /// callers to restrict iteration to a subset of permutations rather than a
     /// contiguous range.
-    fn counts_in_lists(
-        &self,
-        p1: &[usize],
-        p2: &[usize],
-        p3: &[usize],
-        p4: &[usize],
-    ) -> [u32; 4];
+    fn counts_in_lists(&self, p1: &[usize], p2: &[usize], p3: &[usize], p4: &[usize]) -> [u32; 4];
 }
 
 /// In-memory implementation of [`GameDatabase`].
@@ -76,13 +70,7 @@ impl GameDatabase for InMemoryGameDatabase {
         counts
     }
 
-    fn counts_in_lists(
-        &self,
-        p1: &[usize],
-        p2: &[usize],
-        p3: &[usize],
-        p4: &[usize],
-    ) -> [u32; 4] {
+    fn counts_in_lists(&self, p1: &[usize], p2: &[usize], p3: &[usize], p4: &[usize]) -> [u32; 4] {
         let mut counts = [0u32; 4];
         for &i1 in p1 {
             for &i2 in p2 {

--- a/src/game.rs
+++ b/src/game.rs
@@ -262,21 +262,28 @@ impl GameState {
         for &idx in &playable {
             let card = player.hand[idx];
             let orig = self.find_orig_index(p_idx, card);
-            let mut ranges: [std::ops::Range<usize>; 4] =
-                std::array::from_fn(|_| 0..HAND_PERMUTATIONS);
+            let mut lists: [Vec<usize>; 4] = std::array::from_fn(|_| Vec::new());
             for i in 0..4 {
                 let mut prefix = self.played[i].clone();
                 if i == p_idx {
                     prefix.push(orig);
                 }
                 let (s, e) = perm_prefix_range(&prefix);
-                ranges[i] = s..e;
+                if let Some(ref allowed_indices) = self.perm_range {
+                    lists[i] = allowed_indices
+                        .iter()
+                        .cloned()
+                        .filter(|&v| v >= s && v < e)
+                        .collect();
+                } else {
+                    lists[i] = (s..e).collect();
+                }
             }
-            let counts = self.db.counts_in_ranges(
-                ranges[0].clone(),
-                ranges[1].clone(),
-                ranges[2].clone(),
-                ranges[3].clone(),
+            let counts = self.db.counts_in_lists(
+                &lists[0],
+                &lists[1],
+                &lists[2],
+                &lists[3],
             );
             let team = p_idx % 2;
             let wins = counts[if team == 0 {
@@ -307,20 +314,28 @@ impl GameState {
         let player = &self.players[p_idx];
         let card = player.hand[hand_idx];
         let orig = self.find_orig_index(p_idx, card);
-        let mut ranges: [std::ops::Range<usize>; 4] = std::array::from_fn(|_| 0..HAND_PERMUTATIONS);
+        let mut lists: [Vec<usize>; 4] = std::array::from_fn(|_| Vec::new());
         for i in 0..4 {
             let mut prefix = self.played[i].clone();
             if i == p_idx {
                 prefix.push(orig);
             }
             let (s, e) = perm_prefix_range(&prefix);
-            ranges[i] = s..e;
+            if let Some(ref allowed_indices) = self.perm_range {
+                lists[i] = allowed_indices
+                    .iter()
+                    .cloned()
+                    .filter(|&v| v >= s && v < e)
+                    .collect();
+            } else {
+                lists[i] = (s..e).collect();
+            }
         }
-        let counts = self.db.counts_in_ranges(
-            ranges[0].clone(),
-            ranges[1].clone(),
-            ranges[2].clone(),
-            ranges[3].clone(),
+        let counts = self.db.counts_in_lists(
+            &lists[0],
+            &lists[1],
+            &lists[2],
+            &lists[3],
         );
         let team = p_idx % 2;
         let wins = counts[if team == 0 {
@@ -728,6 +743,16 @@ mod tests {
                 *c += 1;
                 result
             }
+
+            fn counts_in_lists(
+                &self,
+                _p1: &[usize],
+                _p2: &[usize],
+                _p3: &[usize],
+                _p4: &[usize],
+            ) -> [u32; 4] {
+                self.counts_in_ranges(0..0, 0..0, 0..0, 0..0)
+            }
         }
 
         let counter = Rc::new(RefCell::new(0));
@@ -771,6 +796,16 @@ mod tests {
             ) -> [u32; 4] {
                 *self.calls.borrow_mut() += 1;
                 [0, 5, 10, 0]
+            }
+
+            fn counts_in_lists(
+                &self,
+                _p1: &[usize],
+                _p2: &[usize],
+                _p3: &[usize],
+                _p4: &[usize],
+            ) -> [u32; 4] {
+                self.counts_in_ranges(0..0, 0..0, 0..0, 0..0)
             }
         }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -279,12 +279,9 @@ impl GameState {
                     lists[i] = (s..e).collect();
                 }
             }
-            let counts = self.db.counts_in_lists(
-                &lists[0],
-                &lists[1],
-                &lists[2],
-                &lists[3],
-            );
+            let counts = self
+                .db
+                .counts_in_lists(&lists[0], &lists[1], &lists[2], &lists[3]);
             let team = p_idx % 2;
             let wins = counts[if team == 0 {
                 GameResult::Team1Win as usize
@@ -331,12 +328,9 @@ impl GameState {
                 lists[i] = (s..e).collect();
             }
         }
-        let counts = self.db.counts_in_lists(
-            &lists[0],
-            &lists[1],
-            &lists[2],
-            &lists[3],
-        );
+        let counts = self
+            .db
+            .counts_in_lists(&lists[0], &lists[1], &lists[2], &lists[3]);
         let team = p_idx % 2;
         let wins = counts[if team == 0 {
             GameResult::Team1Win as usize


### PR DESCRIPTION
## Summary
- allow counting game results over arbitrary index lists
- filter permutation indices using the configured `perm_range`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b5278bd4c83248449dc80f97e1ad1