### PR TITLE
Add Firefox UI test

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,6 +6,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   testDir: __dirname,
+  projects: [
+    {
+      name: 'firefox',
+      use: { browserName: 'firefox' },
+    },
+  ],
   webServer: {
     command: 'npx --yes http-server dist -p 4177',
     port: 4177,

--- a/frontend/ui.spec.ts
+++ b/frontend/ui.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const baseURL = 'file://' + path.resolve(__dirname, 'dist/index.html');
+const baseURL = 'http://localhost:4177';
 
 // Basic sanity check that the built UI loads
 // and renders the game title.

--- a/frontend/ui_full_game.spec.ts
+++ b/frontend/ui_full_game.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseURL = 'http://localhost:4177';
+
+function parseScores(text: string): [number, number] {
+  const m = text.match(/Scores:\s*(\d+)\s*-\s*(\d+)/);
+  if (!m) throw new Error('Could not parse scores from: ' + text);
+  return [parseInt(m[1], 10), parseInt(m[2], 10)];
+}
+
+test('play full game to 13 points', async ({ page, browserName }) => {
+  test.setTimeout(120000);
+  test.skip(browserName !== 'firefox', 'runs only on Firefox');
+  await page.goto(baseURL);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Watten');
+
+  const scoreLocator = page.locator('p', { hasText: /^Scores:/ });
+
+  while (true) {
+    const scoreText = await scoreLocator.innerText();
+    const [a, b] = parseScores(scoreText);
+    if (a >= 13 || b >= 13) break;
+    const card = page.locator('.player.hand .card.selectable').first();
+    await card.waitFor({ state: 'visible' });
+    await card.click();
+    await page.waitForTimeout(100);
+  }
+
+  const finalText = await scoreLocator.innerText();
+  const [s1, s2] = parseScores(finalText);
+  expect(s1 >= 13 || s2 >= 13).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- configure Playwright to only use Firefox
- make UI tests access the http server
- add Playwright spec that plays through a full game automatically

## Testing
- `npm --prefix frontend test`
- `npm run test:ui` *(fails: browser couldn't launch or page not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ddc58eedc8324ba6640c63a7774f6