### PR TITLE
Add root npm start step for wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ frontend/pkg-test
 frontend/node_modules
 frontend/dist
 frontend/test-results
+node_modules

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ tool and a recent Node.js installation.
 
 ### Building and running
 
+You can build the WebAssembly package, install JavaScript dependencies and
+start the development server with a single command from the repository root.
+The command runs `wasm-pack build` under the hood to compile the Rust code:
+
+```bash
+npm start
+```
+
+Open `http://localhost:5173` in your browser.
+
+If you prefer to run the steps manually:
+
 1. Compile the Rust code to WebAssembly from the repository root:
 
    ```bash
@@ -40,8 +52,6 @@ tool and a recent Node.js installation.
    npm install
    npm start
    ```
-
-   Open `http://localhost:5173` in your browser.
 
 3. To create a production build run:
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "npm --prefix frontend install && npm --prefix frontend run build:wasm && npm --prefix frontend exec vite"
+  }
+}


### PR DESCRIPTION
## Summary
- update root `npm start` to build Rust to Wasm before launching Vite
- clarify in README that the command runs `wasm-pack build`

## Testing
- `cargo test`
- `npm --prefix frontend test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687e883353dc8324b2ef2a8b106bbe45