### PR TITLE
Fix WebAssembly path for Vite dev server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:wasm": "wasm-pack build --target web",
+    "build:wasm": "wasm-pack build --target web --out-dir frontend/pkg",
     "build:wasm:test": "wasm-pack build --target nodejs --out-dir pkg-test --dev",
     "start": "npm run build:wasm && vite",
     "build": "npm run build:wasm && vite build",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import init, { WasmGame } from '../../pkg/watten';
+import init, { WasmGame } from '../pkg/watten';
 import './table.css';
 import { CardView } from './Card';
 


### PR DESCRIPTION
## Summary
- output wasm build into `frontend/pkg`
- update React app to load wasm from the new location

## Testing
- `cargo test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e9216dd5883249a53e9e52855e89f